### PR TITLE
Fix for iOS 10 compatibility

### DIFF
--- a/ios/RNDocumentInteractionController/RNDocumentInteractionController/RNDocumentInteractionController.m
+++ b/ios/RNDocumentInteractionController/RNDocumentInteractionController/RNDocumentInteractionController.m
@@ -17,7 +17,9 @@ RCT_EXPORT_METHOD(open: (NSURL *)path)
 {
     UIDocumentInteractionController *interactionController = [UIDocumentInteractionController interactionControllerWithURL:path];
     interactionController.delegate = self;
-    [interactionController presentPreviewAnimated:YES];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [interactionController presentPreviewAnimated:YES];
+    });
 }
 
 - (UIViewController *) documentInteractionControllerViewControllerForPreview: (UIDocumentInteractionController *) controller


### PR DESCRIPTION
On iOS 10, this component throws the exception `Accessing _cachedSystemAnimationFence requires the main thread`. The exact same problem was documented and fixed for [react-native-fetch-blob](https://github.com/wkh237/react-native-fetch-blob/issues/168), and this pull request is the exact same fix.